### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.1.1] - 2025-09-17
+
+### ⚙️ Miscellaneous Tasks
+
+- Release v0.1.0 ([#2](https://github.com/kairsas/rust-payload-offloading-for-aws/pull/2))
 ## [0.1.0] - 2025-09-17
 
 ### 🚀 Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payload-offloading-for-aws"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.86"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `payload-offloading-for-aws`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1] - 2025-09-17

### ⚙️ Miscellaneous Tasks

- Release v0.1.0 ([#2](https://github.com/kairsas/rust-payload-offloading-for-aws/pull/2))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).